### PR TITLE
Bugfix/get serve ip port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,50 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "Debug executable 'crab-dlna' play",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=crab-dlna",
+                    "--package=crab-dlna"
+                ],
+                "filter": {
+                    "name": "crab-dlna",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "play",
+                "-n",
+                "-q",
+                "Kodi",
+                "sample/video.mp4"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'crab-dlna' list",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=crab-dlna",
+                    "--package=crab-dlna"
+                ],
+                "filter": {
+                    "name": "crab-dlna",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "list"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "Debug unit tests in executable 'crab-dlna'",
             "cargo": {
                 "args": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,8 +38,8 @@
                 }
             },
             "args": [
+                "-b",
                 "play",
-                "-n",
                 "-q",
                 "Kodi",
                 "sample/video.mp4"
@@ -62,6 +62,7 @@
                 }
             },
             "args": [
+                "-b",
                 "list"
             ],
             "cwd": "${workspaceFolder}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crab-dlna"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gabriel Magno <gabrielmagno1@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/gabrielmagno/crab-dlna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ pin-utils = "0.1"
 xml-rs = "0.8"
 http = "0.2"
 rupnp = "1.1"
+local-ip-address = "0.4.6"
 warp = "0.3"
 clap = { version = "3.1.15", features = ["derive"] }
 slugify = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 pin-utils = "0.1"
 xml-rs = "0.8"
 http = "0.2"
-rupnp = { version = "1.1.2", git = "https://github.com/gabrielmagno/rupnp" }
+rupnp = "1.1"
 local-ip-address = "0.4.6"
 warp = "0.3"
 clap = { version = "3.1.15", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 pin-utils = "0.1"
 xml-rs = "0.8"
 http = "0.2"
-rupnp = "1.1"
+rupnp = { version = "1.1", git = "https://github.com/gabrielmagno/rupnp" }
 local-ip-address = "0.4.6"
 warp = "0.3"
 clap = { version = "3.1.15", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 pin-utils = "0.1"
 xml-rs = "0.8"
 http = "0.2"
-rupnp = { version = "1.1", git = "https://github.com/gabrielmagno/rupnp" }
+rupnp = { version = "1.1.2", git = "https://github.com/gabrielmagno/rupnp" }
 local-ip-address = "0.4.6"
 warp = "0.3"
 clap = { version = "3.1.15", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Add `crab-dlna` and `tokio` to your dependencies:
 ```toml
 [dependencies] 
 tokio = { version = "1", features = ["full"] }
-crab-dlna = "0.1"
+crab-dlna = "0.1.1"
 ```
 
 ### Example: discover and list devices

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ use crab_dlna::{
     Render,
     RenderSpec,
     MediaStreamingServer,
-    get_serve_ip,
+    get_local_ip,
     infer_subtitle_from_video,
     Error,
     play,
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Error> {
     let discover_timeout_secs = 5;
     let render_spec = RenderSpec::Query(discover_timeout_secs, "Kodi".to_string());
     let render = Render::new(render_spec).await?;
-    let host_ip = get_serve_ip(&render.host()).await?;
+    let host_ip = get_local_ip().await?;
     let video_path = PathBuf::from("/home/crab/Videos/my_video.mp4");
     let inferred_subtitle_path = infer_subtitle_from_video(&video_path);
     let media_streaming_server = MediaStreamingServer::new(

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -1,5 +1,5 @@
 use crab_dlna::{
-    get_serve_ip, infer_subtitle_from_video, play, Error, MediaStreamingServer, Render, RenderSpec,
+    get_local_ip, infer_subtitle_from_video, play, Error, MediaStreamingServer, Render, RenderSpec,
 };
 use std::path::PathBuf;
 
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Error> {
     let discover_timeout_secs = 5;
     let render_spec = RenderSpec::Query(discover_timeout_secs, "Kodi".to_string());
     let render = Render::new(render_spec).await?;
-    let host_ip = get_serve_ip(&render.host()).await?;
+    let host_ip = get_local_ip().await?;
     let video_path = PathBuf::from("/home/crab/Videos/my_video.mp4");
     let inferred_subtitle_path = infer_subtitle_from_video(&video_path);
     let media_streaming_server =

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use crate::{
     devices::{Render, RenderSpec},
     dlna,
     error::Result,
-    streaming::{get_serve_ip, infer_subtitle_from_video, MediaStreamingServer},
+    streaming::{get_local_ip, infer_subtitle_from_video, MediaStreamingServer},
 };
 use clap::{Args, Parser, Subcommand};
 use log::info;
@@ -107,7 +107,7 @@ struct Play {
 impl Play {
     async fn run(&self, cli: &Cli) -> Result<()> {
         let render = self.select_render(cli).await?;
-        let media_streaming_server = self.build_media_streaming_server(&render).await?;
+        let media_streaming_server = self.build_media_streaming_server().await?;
         dlna::play(render, media_streaming_server).await
     }
 
@@ -123,9 +123,9 @@ impl Play {
         .await
     }
 
-    async fn build_media_streaming_server(&self, render: &Render) -> Result<MediaStreamingServer> {
+    async fn build_media_streaming_server(&self) -> Result<MediaStreamingServer> {
         info!("Building media streaming server");
-        let local_host_ip = get_serve_ip(&render.host()).await?;
+        let local_host_ip = get_local_ip().await?;
         let host_ip = self.host.as_ref().unwrap_or(&local_host_ip);
 
         let subtitle = match &self.no_subtitle {

--- a/src/dlna.rs
+++ b/src/dlna.rs
@@ -12,7 +12,7 @@ const PAYLOAD_PLAY: &str = r#"
     <Speed>1</Speed>
 "#;
 
-const STREAMING_SERVER_WAIT_SECS: u64 = 5;
+const STREAMING_SERVER_WAIT_SECS: u64 = 2;
 
 /// Plays a media file in a DLNA compatible device render, according to the render and media streaming server provided
 pub async fn play(render: Render, streaming_server: MediaStreamingServer) -> Result<()> {

--- a/src/dlna.rs
+++ b/src/dlna.rs
@@ -5,11 +5,14 @@ use crate::{
 };
 use log::{debug, info};
 use xml::escape::escape_str_attribute;
+use tokio::time::{sleep, Duration};
 
 const PAYLOAD_PLAY: &str = r#"
     <InstanceID>0</InstanceID>
     <Speed>1</Speed>
 "#;
+
+const STREAMING_SERVER_WAIT_SECS: u64 = 5;
 
 /// Plays a media file in a DLNA compatible device render, according to the render and media streaming server provided
 pub async fn play(render: Render, streaming_server: MediaStreamingServer) -> Result<()> {
@@ -59,6 +62,9 @@ pub async fn play(render: Render, streaming_server: MediaStreamingServer) -> Res
 
     info!("Starting media streaming server...");
     let streaming_server_handle = tokio::spawn(async move { streaming_server.run().await });
+
+    debug!("Explicitly waiting {} seconds for streaming server to finish loading", STREAMING_SERVER_WAIT_SECS);
+    sleep(Duration::from_secs(STREAMING_SERVER_WAIT_SECS)).await;
 
     info!("Setting Video URI");
     render

--- a/src/dlna.rs
+++ b/src/dlna.rs
@@ -5,14 +5,11 @@ use crate::{
 };
 use log::{debug, info};
 use xml::escape::escape_str_attribute;
-use tokio::time::{sleep, Duration};
 
 const PAYLOAD_PLAY: &str = r#"
     <InstanceID>0</InstanceID>
     <Speed>1</Speed>
 "#;
-
-const STREAMING_SERVER_WAIT_SECS: u64 = 2;
 
 /// Plays a media file in a DLNA compatible device render, according to the render and media streaming server provided
 pub async fn play(render: Render, streaming_server: MediaStreamingServer) -> Result<()> {
@@ -62,9 +59,6 @@ pub async fn play(render: Render, streaming_server: MediaStreamingServer) -> Res
 
     info!("Starting media streaming server...");
     let streaming_server_handle = tokio::spawn(async move { streaming_server.run().await });
-
-    debug!("Explicitly waiting {} seconds for streaming server to finish loading", STREAMING_SERVER_WAIT_SECS);
-    sleep(Duration::from_secs(STREAMING_SERVER_WAIT_SECS)).await;
 
     info!("Setting Video URI");
     render

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     /// An error occurred while trying to connect to the render
     StreamingRemoteRenderConnectFail(String, std::io::Error),
     /// An error occurred while trying to identify the host IP address
-    StreamingIdentifyLocalAddressError(std::io::Error),
+    StreamingIdentifyLocalAddressError(local_ip_address::Error),
     /// An error occurred while sending the SetAVTransportURI DLNA action to the render
     DLNASetAVTransportURIError(rupnp::Error),
     /// An error occurred while sending the Play DLNA action to the render
@@ -54,7 +54,7 @@ impl fmt::Display for Error {
                     write!(f, "No render found within {} seconds", timeout)
                 }
             },
-            Error::StreamingHostParseError(host) => write!(f, "Failed to parse host '{}'", host),
+            Error::StreamingHostParseError(addr) => write!(f, "Failed to parse host address '{}'", addr),
             Error::StreamingFileDoesNotExist(file) => write!(f, "File '{}' does not exist", file),
             Error::StreamingRemoteRenderConnectFail(host, err) => {
                 write!(f, "Failed to connect to remote render '{}': {}", host, err)

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,9 @@ impl fmt::Display for Error {
                     write!(f, "No render found within {} seconds", timeout)
                 }
             },
-            Error::StreamingHostParseError(addr) => write!(f, "Failed to parse host address '{}'", addr),
+            Error::StreamingHostParseError(addr) => {
+                write!(f, "Failed to parse host address '{}'", addr)
+            }
             Error::StreamingFileDoesNotExist(file) => write!(f, "File '{}' does not exist", file),
             Error::StreamingRemoteRenderConnectFail(host, err) => {
                 write!(f, "Failed to connect to remote render '{}': {}", host, err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use crab_dlna::{
     Render,
     RenderSpec,
     MediaStreamingServer,
-    get_serve_ip,
+    get_local_ip,
     infer_subtitle_from_video,
     Error,
     play,
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Error> {
     let discover_timeout_secs = 5;
     let render_spec = RenderSpec::Query(discover_timeout_secs, "Kodi".to_string());
     let render = Render::new(render_spec).await?;
-    let host_ip = get_serve_ip(&render.host()).await?;
+    let host_ip = get_local_ip().await?;
     let video_path = PathBuf::from("/home/crab/Videos/my_video.mp4");
     let inferred_subtitle_path = infer_subtitle_from_video(&video_path);
     let media_streaming_server = MediaStreamingServer::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,4 +97,4 @@ mod error;
 pub use devices::{Render, RenderSpec};
 pub use dlna::play;
 pub use error::Error;
-pub use streaming::{get_serve_ip, infer_subtitle_from_video, MediaStreamingServer};
+pub use streaming::{get_local_ip, infer_subtitle_from_video, MediaStreamingServer};

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,8 +1,8 @@
 use crate::error::{Error, Result};
+use local_ip_address::local_ip;
 use log::{debug, info, warn};
 use slugify::slugify;
 use std::net::SocketAddr;
-use local_ip_address::local_ip;
 use warp::Filter;
 
 const STREAMING_PORT: u32 = 9000;

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,10 +1,10 @@
 use crate::error::{Error, Result};
 use log::{debug, info, warn};
 use slugify::slugify;
-use std::net::{SocketAddr, UdpSocket};
+use std::net::SocketAddr;
+use local_ip_address::local_ip;
 use warp::Filter;
 
-const DUMMY_PORT: u32 = 0;
 const STREAMING_PORT: u32 = 9000;
 
 /// A media file to stream
@@ -42,9 +42,10 @@ impl MediaStreamingServer {
         subtitle_path: &Option<std::path::PathBuf>,
         host_ip: &String,
     ) -> Result<Self> {
-        let server_addr: SocketAddr = format!("{}:{}", host_ip, STREAMING_PORT)
+        let server_addr_str = format!("{}:{}", host_ip, STREAMING_PORT);
+        let server_addr: SocketAddr = server_addr_str
             .parse()
-            .map_err(|_| Error::StreamingHostParseError(host_ip.to_owned()))?;
+            .map_err(|_| Error::StreamingHostParseError(server_addr_str))?;
 
         debug!("Streaming server address: {}", server_addr);
 
@@ -161,21 +162,11 @@ impl MediaStreamingServer {
     }
 }
 
-/// Identifies the local serve IP address according to a target host.
-pub async fn get_serve_ip(target_host: &String) -> Result<String> {
-    debug!(
-        "Identifying local serve IP for target host: {}",
-        target_host
-    );
-    let target_addr: SocketAddr = format!("{}:{}", target_host, DUMMY_PORT)
-        .parse()
-        .map_err(|_| Error::StreamingHostParseError(target_host.to_owned()))?;
-
-    Ok(UdpSocket::bind(target_addr)
-        .map_err(|err| Error::StreamingRemoteRenderConnectFail(target_addr.to_string(), err))?
-        .local_addr()
+/// Identifies the local serve IP address.
+pub async fn get_local_ip() -> Result<String> {
+    debug!("Identifying local IP address of host");
+    Ok(local_ip()
         .map_err(Error::StreamingIdentifyLocalAddressError)?
-        .ip()
         .to_string())
 }
 


### PR DESCRIPTION
- Use an external crate (`local-ip-address`) to make better identification of the local IP address to host the streaming.
- The function `get_serve_ip` was renamed to `get_local_ip` to reflect better what it is doing.